### PR TITLE
adding id to the group form to prevent it from creating a new id to g…

### DIFF
--- a/src/app/utils/form-group-builder.ts
+++ b/src/app/utils/form-group-builder.ts
@@ -156,6 +156,7 @@ export default class FormGroupBuilder {
       group = new Group();
     }
     return new FormGroup({
+      id: new FormControl(group.id),
       name: new FormControl(group.name, Validators.required),
       members: new FormControl(group.members.map(x => x.id), Validators.required),
     });


### PR DESCRIPTION
…roups and cause errors in the history