### PR TITLE
Export current report table view

### DIFF
--- a/src/app/components/report/objectGrouping/object-grouping.component.html
+++ b/src/app/components/report/objectGrouping/object-grouping.component.html
@@ -18,7 +18,24 @@
     <mat-grid-tile class="excel-download" colspan="6">
         <mat-form-field appearance="none" class="mdm-form-field" class="dl-select">
             <mat-select disableOptionCentering panelClass="filterClass" placeholder="{{ 'export-download' | translate }}">
-                <mat-option matTooltip="{{ 'minimized-tooltip' | translate }}" (click)="dlMini()">{{ 'export-minimized' | translate }}<mat-icon>info</mat-icon></mat-option>
+                <mat-option (click)="dlMini()">
+                    {{ "export-minimized" | translate}}
+                    <mat-icon
+                        matTooltip="{{ 'minimized-tooltip' | translate }}"
+                        matTooltipPosition="left"
+                    >
+                        info
+                    </mat-icon>
+                </mat-option>
+                <mat-option (click)="dlCurrView()">
+                    {{ "export-current-minimized" | translate}}
+                    <mat-icon
+                    matTooltip="{{ 'export-current-minimized' | translate }}"
+                    matTooltipPosition="left"
+                    >
+                        info
+                    </mat-icon>
+                </mat-option>
                 <!--
                 <mat-option matTooltip="{{ 'complete-tooltip' | translate }}" (click)="downloadExcelSheet()">{{ 'export-complete' | translate }}<mat-icon>info</mat-icon></mat-option>
                 -->

--- a/src/app/components/report/objectGrouping/object-grouping.component.ts
+++ b/src/app/components/report/objectGrouping/object-grouping.component.ts
@@ -4,9 +4,9 @@ import { ProjectService } from 'src/app/services/project.service';
 import { Project } from 'src/app/models/classes/project.model';
 import { Form } from 'src/app/models/classes/form.model';
 import { TranslateService } from '@ngx-translate/core';
-import { MatDialog } from '@angular/material/dialog';
 import { DownloadService } from 'src/app/services/download.service';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ReportingService } from 'src/app/services/reporting.service';
 
 @Component({
   selector: 'app-object-grouping',
@@ -44,12 +44,15 @@ export class ObjectGroupingComponent implements OnInit {
     'group'
   ];
 
-  constructor(private projectService: ProjectService,
-              private fb: FormBuilder,
-              private translateService: TranslateService,
-              private downloadService: DownloadService,
-              private router: Router,
-              private route: ActivatedRoute) { }
+  constructor(
+    private projectService: ProjectService,
+    private fb: FormBuilder,
+    private translateService: TranslateService,
+    private downloadService: DownloadService,
+    private router: Router,
+    private route: ActivatedRoute,
+    private reportingService: ReportingService,
+  ) {}
 
 
   get currentLang(): string {
@@ -165,4 +168,9 @@ export class ObjectGroupingComponent implements OnInit {
     // this.dialog.closeAll();
   }
 
+  /** Downloads the current view of the table */
+  async dlCurrView(): Promise<void> {
+    await this.reportingService.downloadCurrentTableView();
+  }
+  
 }

--- a/src/app/components/report/reporting-table/reporting-table.component.html
+++ b/src/app/components/report/reporting-table/reporting-table.component.html
@@ -1,4 +1,4 @@
-<div class="table-scroll {{ isCrossCuttingReport ? 'big-table' : null }}">
+<div #reportingTable class="table-scroll {{ isCrossCuttingReport ? 'big-table' : null }}">
   <table mat-table [dataSource]="dataSource" multiTemplateDataRows class="mat-elevation-z8">
     <ng-container class="menu" matColumnDef="icon" [sticky]="true">
       <th mat-header-cell *matHeaderCellDef></th>

--- a/src/app/components/report/reporting-table/reporting-table.component.ts
+++ b/src/app/components/report/reporting-table/reporting-table.component.ts
@@ -1,6 +1,6 @@
 // tslint:disable: variable-name
 // tslint:disable:no-string-literal
-import { Component, ElementRef, HostListener, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, HostListener, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
@@ -34,7 +34,7 @@ type Row = SectionTitle | GroupTitle | InfoRow;
   templateUrl: './reporting-table.component.html',
   styleUrls: ['./reporting-table.component.scss']
 })
-export class ReportingTableComponent implements OnInit, OnDestroy {
+export class ReportingTableComponent implements OnInit, OnDestroy, AfterViewInit {
 
   constructor(private projectService: ProjectService,
               private reportingService: ReportingService,
@@ -51,6 +51,7 @@ export class ReportingTableComponent implements OnInit, OnDestroy {
     return this.translateService.currentLang ? this.translateService.currentLang : this.translateService.defaultLang;
   }
 
+  @ViewChild('reportingTable') tableRef: ElementRef;
   @Input() tableContent: BehaviorSubject<any[]>;
   @Input() dimensionIds: BehaviorSubject<string>;
   @Input() filter: BehaviorSubject<Filter>;
@@ -200,6 +201,10 @@ export class ReportingTableComponent implements OnInit, OnDestroy {
         }
       })
     );
+  }
+
+  ngAfterViewInit(): void {
+    this.reportingService.currReportTable.next(this.tableRef);
   }
 
   updateTableContent(): void {

--- a/src/app/services/reporting.service.ts
+++ b/src/app/services/reporting.service.ts
@@ -1,14 +1,20 @@
 // tslint:disable: no-string-literal
-import { Injectable } from '@angular/core';
+import * as XLSX from 'xlsx';
+import { ElementRef, Injectable } from '@angular/core';
 import { ApiService } from './api.service';
 import TimeSlot from 'timeslot-dag';
-
+import { BehaviorSubject } from 'rxjs';
+import { ProjectService } from './project.service';
 @Injectable({
   providedIn: 'root'
 })
 export class ReportingService {
+  public currReportTable = new BehaviorSubject<ElementRef>(null);
 
-  constructor(private apiService: ApiService) { }
+  constructor(
+    private apiService: ApiService,
+    private projectService: ProjectService
+  ) {}
 
   public TIME_PERIODICITIES = [
     'day', 'month_week_sat', 'month_week_sun', 'month_week_mon', 'week_sat', 'week_sun',
@@ -117,6 +123,108 @@ export class ReportingService {
     });
   }
 
+  /** Downloads current reporting table view */
+  async downloadCurrentTableView(): Promise<void> {
+    const table = {
+      nativeElement: this.currReportTable
+        .getValue()
+        .nativeElement.cloneNode(true)
+    };
 
+    // remove all buttons
+    const btnRegex = /<button.*?>(.*?)<\/button>/g;
+    table.nativeElement.innerHTML = table.nativeElement.innerHTML.replace(
+      btnRegex,
+      ''
+    );
+
+    // remove inly add_circle and remove_circle icons
+    const addRmBtnRegex = /<mat-icon.*?>(add_circle|remove_circle)<\/mat-icon>/g;
+    table.nativeElement.innerHTML = table.nativeElement.innerHTML.replace(
+      addRmBtnRegex,
+      ''
+    );
+
+    // replace 'do_disturb' icon with '🚫'
+    const doDisturbRegex = /<mat-icon.*?>do_disturb<\/mat-icon>/g;
+    table.nativeElement.innerHTML = table.nativeElement.innerHTML.replace(
+      doDisturbRegex,
+      '🚫'
+    );
+
+    // get the header of the table
+    const headers: string[] = [];
+    const ths = table.nativeElement.querySelectorAll('th');
+    for (const th of ths) headers.push(th.innerText);
+    headers.shift();
+
+    // get the padding values the tds in each row,
+    // that will be used to determine the color of the row
+    const trs = table.nativeElement.querySelectorAll('tr');
+    const paddingValues: number[] = [];
+    for (const tr of trs) {
+      // console.log('new tr', tr)
+      const tds = tr.querySelectorAll('td');
+      if (tds.length !== 0 && tds[0].innerText !== '') {
+        paddingValues.push(0);
+        continue;
+      }
+      let flag = false;
+      for (const td of tds) {
+        if (td.style.paddingLeft) {
+          paddingValues.push(
+            (parseInt(td.style.paddingLeft.slice(0, -2), 10) + 10) / 10
+          );
+          flag = true;
+          break;
+        }
+      }
+      if (!flag) {
+        paddingValues.push(1);
+      }
+    }
+    paddingValues.shift();
+
+    const ws: XLSX.WorkSheet = XLSX.utils.table_to_sheet(table.nativeElement, {
+      raw: true
+    });
+
+    // parse table to json, in order to send it to the server
+    // (we can't do style stuff with the front-end library)
+    const json = XLSX.utils.sheet_to_json(ws);
+    json.forEach(row => {
+      if (row['']) {
+        row['Name'] = row[''];
+        delete row[''];
+      }
+    });
+
+    const file = await this.apiService.post(
+      '/export/currentView',
+      {
+        data: json,
+        paddings: paddingValues,
+        headers
+      },
+      {
+        responseType: 'blob'
+      }
+    );
+
+    // save file to the user's computer
+    const blob = new Blob([file], {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    
+    // filename format is 'monitool-<project name>.xlsx'
+    const projectCountry = this.projectService.project.getValue().country;
+    a.download = `monitool-${projectCountry}.xlsx`;
+    a.click();
+    window.URL.revokeObjectURL(url);
+    a.remove();
+  }
 }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -796,6 +796,7 @@
     "export-download": "Download Excel Report",
     "export-complete": "Detailed Excel Export",
     "export-minimized": "Global Excel Export",
+    "export-current-minimized": "Current View Excel Report",
     "minimized-tooltip": "All Sites merged",
     "complete-tooltip": "Global Export + 1 Tab per Collecion Site",
     "NullValueMessage": {

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -812,6 +812,7 @@
     "export-download": "Descargar informe Excel",
     "export-complete": "Exportación detallada de Excel",
     "export-minimized": "Exportación global de Excel",
+    "export-current-minimized": "Informe de Excel de vista actual",
     "minimized-tooltip": "Todos los sitios combinados",
     "complete-tooltip": "Exportación global + 1 pestaña por sitio de colección",
     "NullValueMessage": {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -813,6 +813,7 @@
     "export-download": "Télécharger le rapport Excel",
     "export-complete": "Export Excel détaillé",
     "export-minimized": "Export Excel Global",
+    "export-current-minimized": "Rapport Excel de la vue actuelle",
     "minimized-tooltip": "Tous sites confondus",
     "complete-tooltip": "Rapport Total + 1 onglet par site de collecte",
     "Groups": "Groupe d’éléments",


### PR DESCRIPTION
This PR implements the export of the report's current view table.

The parsing from HTML to JSON is done in the front end (we also extract some other information that will be sent in the request). The JSON will be parsed in the backend and the front gets the xlsx file in the end.