### PR TITLE
fix: save on 0 input

### DIFF
--- a/src/app/modules/project/modules/input/pages/edit/edit.component.ts
+++ b/src/app/modules/project/modules/input/pages/edit/edit.component.ts
@@ -488,7 +488,7 @@ export class EditComponent implements OnInit, OnDestroy, ComponentCanDeactivate 
             callback(false);
           }
         },
-        afterValidate: (core, isValid, value, row, prop, source) => {
+        afterValidate: (isValid, value, row, prop, source) => {
           this.validInputCell = isValid;
           if (value === '') {
             this.validInputCell = true;


### PR DESCRIPTION
I think the bug was happening because of a library update (I think)

The function should be of type

`afterValidate?: (isValid: boolean, value: CellValue, row: number, prop: string | number, source: ChangeSource) => void | boolean;
`